### PR TITLE
Fixed bugs in grid sorting

### DIFF
--- a/src/widgets/grid.js
+++ b/src/widgets/grid.js
@@ -135,8 +135,8 @@ define([
                 }
                 
                 if (col.sortable) {       
-                    var $orderIndicators = $(' <span class=asc-arrow>&#x25b2;</span><span class=desc-arrow>&#x25bc;</span>');
-                    $th.append($orderIndicators);
+                    var $orderSpans = $(' <span class=asc-arrow>&#x25b2;</span><span class=desc-arrow>&#x25bc;</span>');                    
+                    col.resizable? $th.find('.buffer').append($orderSpans): $th.append($orderSpans);                      
                     $th.addClass('sort-null');
                     $th.on('click', function(evt) {
                         if (col.order === 'asc') {
@@ -145,14 +145,14 @@ define([
                             col.order = 'asc';
                         }
                         self._sortData(self, col);
-                    });
-                    
-                 // initial sorting
-                    if (col.order !== undefined) {
-                        self._sortData(self, col);
-                    }
+                    });                                   
                 } 
                 $th.appendTo($tr);
+                
+                // initial sorting
+                if (col.sortable && col.order !== undefined) {
+                    self._sortData(self, col);
+                }
             });
         },
 
@@ -168,9 +168,9 @@ define([
                 .removeClass('sort-null')
                 .addClass(col.order === 'asc'? 'sort-asc': 'sort-desc');
             
-            // set will take care of sorting   
+            // set will take care of sorting
+            self._sortedColumn = col;
             if (self.options.models) {
-                self._sortedColumn = col;
                 self.set('models', self.options.models);                                                        
             }
         },
@@ -184,8 +184,9 @@ define([
                     result = -1;
                 } else if (!b[colName]) {
                     result = 1;
+                } else {               
+                    result = ((a[colName] < b[colName]) ? -1 : ((a[colName] > b[colName]) ? 1 : 0));
                 }
-                result = ((a[colName] < b[colName]) ? -1 : ((a[colName] > b[colName]) ? 1 : 0));
                 
                 result *= colOrder === 'asc'? 1 : -1;
                 
@@ -203,8 +204,13 @@ define([
                 rows = options.rows,
                 rowsLen = rows.length,
                 $tbody = this.$tbody,
-                tbody = $tbody[0];
+                tbody = $tbody[0],
+                selectedModel = null;
 
+            if (this._highlighted) {
+                selectedModel = this._highlighted.options.model;
+            }
+                        
             if (this._shouldFullyRender()) {
                 $tbody.remove();
                 $tbody = this.$tbody = $('<tbody></tbody>');
@@ -217,6 +223,8 @@ define([
                 models = models.sort(this._compare(this._sortedColumn.name, this._sortedColumn.order));
             }
             
+            this.unhighlight();
+            
             for (i = 0; i < len; i++) {
                 model = models[i];
                 if (i >= rowsLen) {
@@ -225,6 +233,10 @@ define([
                     rows.push(newRow);
                 } else {
                     this.setModel(rows[i], model);
+                }
+                
+                if (selectedModel && model === selectedModel) {
+                    this.highlight(rows[i]);
                 }
             }
 

--- a/src/widgets/grid/test.js
+++ b/src/widgets/grid/test.js
@@ -248,13 +248,13 @@ define([
     asyncTest('sort column', function() {
         var limit = 100, grid = this.grid, collection = this.collection,
             prevModel = null,
-            dataModel = null;
+            dataModel = null,
+            $nameColTh = grid.$node.find('thead th.col-name');
         grid.appendTo($('#qunit-fixture'));
         
         collection.load({limit: limit, offset: 0}).done(function(data) {
             grid.set('models', data);
-            
-            $nameColTh = grid.$node.find('thead th.col-name');
+                        
             $nameColTh.trigger('click');
                         
             equal(grid.options.models.length, limit);
@@ -265,7 +265,9 @@ define([
                 }   
                 prevModel = model; 
                 
-                dataModel = _.find(data, function(d) { return d.name === model.name});
+                dataModel = _.find(data, function(d) { 
+                    return d.name === model.name;
+                });
                 equal(model.name, dataModel.name);
                 equal(model.tasks_option, dataModel.tasks_option);
                 equal(model.volume_id, dataModel.volume_id);
@@ -282,7 +284,9 @@ define([
                 }   
                 prevModel = model;
                 
-                dataModel = _.find(data, function(d) { return d.name === model.name});
+                dataModel = _.find(data, function(d) { 
+                    return d.name === model.name;
+                });
                 equal(model.name, dataModel.name);
                 equal(model.tasks_option, dataModel.tasks_option);
                 equal(model.volume_id, dataModel.volume_id);
@@ -296,7 +300,8 @@ define([
     asyncTest('reset data with sorted column', function() {
         var limit = 100, grid = this.grid, collection = this.collection,
             prevModel = null,
-            dataModel = null;
+            dataModel = null,
+            $nameColTh = grid.$node.find('thead th.col-name');
         grid.appendTo($('#qunit-fixture'));
         
         $.when(
@@ -305,7 +310,6 @@ define([
             ).done(function(data1, data2) {
             grid.set('models', data1[0]);
             
-            $nameColTh = grid.$node.find('thead th.col-name');
             $nameColTh.trigger('click');    // sort ascending                        
             $nameColTh.trigger('click');    // sort descending
             
@@ -318,12 +322,43 @@ define([
                 }   
                 prevModel = model;
                 
-                dataModel = _.find(data2[0], function(d) { return d.name === model.name});
+                dataModel = _.find(data2[0], function(d) { 
+                    return d.name === model.name;
+                });
                 equal(model.name, dataModel.name);
                 equal(model.tasks_option, dataModel.tasks_option);
                 equal(model.volume_id, dataModel.volume_id);
                 equal(model.security_attributes, dataModel.security_attributes);
             });                
+            setTimeout(start, 15);
+
+        });
+    });
+    
+    asyncTest('reset data with highlighted row and sorted colum', function() {
+        var limit = 100, grid = this.grid, collection = this.collection,
+            selectedModel = null,
+            $nameColTh = grid.$node.find('thead th.col-name');
+        grid.appendTo($('#qunit-fixture'));
+        
+        $.when(
+                collection.load({limit: limit, offset: 0}),
+                collection.load({limit: limit, offset: limit})
+            ).done(function(data1, data2) {
+            grid.set('models', data1[0]);
+            grid.highlight(grid.options.rows[0]);
+            
+            selectedModel = grid.highlighted().options.model;
+            
+            $nameColTh.trigger('click');    // sort ascending
+            equal(selectedModel.id, grid.highlighted().options.model.id);
+            
+            $nameColTh.trigger('click');    // sort descending
+            equal(selectedModel.id, grid.highlighted().options.model.id);
+            
+            grid.set('models', data2[0]);
+            equal(null, grid.highlighted());
+            
             setTimeout(start, 15);
 
         });


### PR DESCRIPTION
1. Sortable + resizable column did not render order indicators properly.
2. Initial sorting indicator was not being set properly.
3. Sorting was giving errors on grid with no models.
4. Error in compare method
5. Selected record was not highlighted correctly after sorting.
