### PR TITLE
Messagebox upgrade

### DIFF
--- a/src/widgets/messagebox.js
+++ b/src/widgets/messagebox.js
@@ -12,7 +12,10 @@ define([
         defaults: {
             okBtn: '', // provide a label to have an ok button in the lower right corner
             cancelBtn: '', // provide a label to have a cancel button in the lower right corner
-            body: ''
+            body: '', // Message Body
+            okBtnEvent: 'ok', // to rename the button event, provide a name here
+            cancelBtnEvent: 'cancel', // to rename the button event, provide a name here
+            style: '' // provide a style here. the style will be directly applied to the messagebox icon class if provided. 
         },
         
         create: function() {
@@ -31,17 +34,20 @@ define([
                 Button($('<button>'+self.options.okBtn+'</button>').appendTo(self.$node))
                     .on('click', self.ok);
             }
+            if (self.options.style !== '') {
+                self.$node.find('.message-icon').addClass(self.options.style);
+            }
         },
         
         ok: function() {
             var self = this;
-            self.trigger('ok');
+            self.trigger(self.options.okBtnEvent);
             self.close();
         },
         
         cancel: function() {
             var self = this;
-            self.trigger('cancel');
+            self.trigger(self.options.cancelBtnEvent);
             self.close();
         }
     });    

--- a/src/widgets/messagebox/messagebox.css
+++ b/src/widgets/messagebox/messagebox.css
@@ -1,9 +1,50 @@
 .message-box .message-body {
-  padding: 10px 10px 30px 10px;
-  border-bottom: 1px solid #BBD;
-  max-width: 350px; 
+  padding-top: 10px;
+  padding-bottom: 30px;
+  margin-left: 5px;
+  margin-right: 5px;
+  width: 100%;
+  max-width: 450px; 
 }
+
+.message-box .message-separator {
+    border-bottom: 1px solid #BBD;
+}
+
+.message-box .message-text {
+  float: left;
+}
+
 .message-box button {
   float: right;
   margin: 5px 10px 10px 10px;
+}
+
+.message-box .message-icon {
+    margin-right: 10px;
+    float: left;
+}
+
+.message-box .error {
+  width: 48px;
+  height: 48px;
+  background-image:url('/static/components/lookandfeel/img/error-icon.png');
+}
+
+.message-box .warning {
+  width: 48px;
+  height: 48px;
+  background-image:url('/static/components/lookandfeel/img/warning-icon.png');
+}
+  
+.message-box .question {
+  width: 48px;
+  height: 48px;
+  background-image:url('/static/components/lookandfeel/img/question-icon.png');
+}
+  
+.message-box .information {
+  width: 48px;
+  height: 48px;
+  background-image:url('/static/components/lookandfeel/img/information-icon.png');
 }

--- a/src/widgets/messagebox/messagebox.mtpl
+++ b/src/widgets/messagebox/messagebox.mtpl
@@ -1,4 +1,8 @@
 <div class=message-box>
-  <div class=message-body />
-  <div class='clear: both' />
+  <div class=message-body>
+    <div class=message-icon></div>
+    <div class=message-text />
+    <div class='clear: both' />
+  </div>
+  <div class=message-separator>
 </div>

--- a/src/widgets/messagebox/test.js
+++ b/src/widgets/messagebox/test.js
@@ -37,15 +37,43 @@ define([
         ok(m);
     });
 
-    test('Visual Test', function () {
+    test('MessageBox instantiation with event aliases', function () {
         var m = MessageBox(undefined, {
             title: 'Test MessageBox',
             body: 'Test Message Box With Both Buttons',
+            okBtn: 'Oks',
+            cancelBtn: 'Cancels',
+            okBtnEvent: 'okAlias',
+            cancelBtnEvent: 'cancelAlias'
+        }).appendTo('#qunit-fixture');
+        ok(m);
+    });
+
+    test('MessageBox instantiation with type', function () {
+        var m = MessageBox(undefined, {
+            title: 'Test MessageBox',
+            body: 'Test Message Box With Both Buttons',
+            okBtn: 'Oks',
+            cancelBtn: 'Cancels',
+            okBtnEvent: 'okAlias',
+            cancelBtnEvent: 'cancelAlias',
+            style: 'error'
+        }).appendTo('#qunit-fixture');
+        ok(m);
+    });
+
+    test('Visual Test', function () {
+        var m = MessageBox(undefined, {
+            title: 'Test MessageBox',
+            body: 'Test Message Box With Both Buttons and a message that is really long but absolutely meaningless. Trying to make it longer is of little to no use as well. ',
             okBtn: 'Ok',
-            cancelBtn: 'Cancel'
-        }).on('ok', function() {
+            cancelBtn: 'Cancel',
+            okBtnEvent: 'OkBtnAlias',
+            cancelBtnEvent: 'CancelBtnAlias',
+            style: 'error'
+        }).on('OkBtnAlias', function() {
             alert('Ok Pressed')
-        }).on('cancel', function() {
+        }).on('CancelBtnAlias', function() {
             alert('Cancel Pressed')
         }).appendTo('body');
 


### PR DESCRIPTION
Hi Aaron, 

I have generated a pull request for the MessageBox widget. The following changes are of note.
1. a style property is added. The style property is set as the class for the message box icon .
2. Two properties (okBtnEvent/cancelBtnEvent) have been added. These can be used to provide different event names for the ok/cancel button. 

Test cases have already been added to lookandfeel repo and comitted.
