### PR TITLE
CollectionViewable: Added listener to handle updates in all scenarios

### DIFF
--- a/src/widgets/collectionviewable.js
+++ b/src/widgets/collectionviewable.js
@@ -30,12 +30,13 @@ define([
                         if (self.enable) {
                             self.enable();
                         }
-
-                        // handle any future updates
-                        collection.on('update', function(evtName, collection) {
-                            self.set('models', collection.models);
-                        });
                     });
+                    
+                    // Add listener on the collection to handle further updates 
+                    collection.on('update', function(evtName, collection) {
+                        self.set('models', collection.models);
+                    });
+
                 } else {
                     self.set('models', []);
                 }


### PR DESCRIPTION
- Previously this listener was only being added on success of load function, which works fine in normal scenarios. But in case of race condition, where response for 2nd load request comes before this request, the success path of this request never gets executed and in turn the update event listener never gets registered to this collection.

One question, related to this event listener, In Line of 23 of this file, we are using collectionMap before setting models in the widget, do we need to do same in this event listener?
