### PR TITLE
accept array of models for PowerGrid#select()

### DIFF
--- a/src/widgets/powergrid.js
+++ b/src/widgets/powergrid.js
@@ -464,34 +464,39 @@ define([
             var indices, self = this, changes = [],
                 a = self.get('selectedAttr'),
                 models = self.get('models'),
+                selectModels = _.isArray(model)? model : [model],
                 selected = function(m) { return m.get(a); };
 
             opts = opts || {};
 
             // first just get a list of all the changes that need to happen
-            if (!opts.dontUnselectOthers) {
+            if (!opts.dontUnselectOthers && !opts.selectTo) {
                 _.each(models, function(m) {
-                    if (m !== model && m.get(a)) {
+                    if (selectModels.indexOf(m) < 0 && m.get(a)) {
                         changes.push({model: m, action: 'del'});
                     }
                 });
             }
 
             if (opts.selectTo && _.any(models, selected)) {
-                indices = [
+                indices = _.filter([
                     _.indexOf(_.map(models, selected), true),
                     _.lastIndexOf(_.map(models, selected), true),
                     _.indexOf(models, model)
-                ];
+                ], function(idx) {
+                    return idx >= 0;
+                });
                 _.each(_.range(_.min(indices), _.max(indices)), function(i) {
-                    if (models[i] !== model && !models[i].get(a)) {
+                    if (!models[i].get(a)) {
                         changes.push({model: models[i], action: 'set'});
                     }
                 });
-            }
-
-            if (!model.get(a)) {
-                changes.push({model: model, action: 'set'});
+            } else {
+                _.each(selectModels, function(m) {
+                    if (!m.get(a)) {
+                        changes.push({model: m, action: 'set'});
+                    }
+                });
             }
 
             // now we actually make the changes, silently for everything but

--- a/src/widgets/powergrid/test.js
+++ b/src/widgets/powergrid/test.js
@@ -432,6 +432,31 @@ define([
         });
     });
 
+    asyncTest('calling select with an array of models', function() {
+        setup({
+            gridOptions: {selectable: 'multi'},
+            appendTo: '#qunit-fixture'
+        }).then(function(g, options) {
+            var models = g.get('models').slice(1, 4);
+
+            var $selected = g.$el.find('.selected');
+            equal($selected.length, 0, 'no models initiall selected');
+
+            g.select(models);
+
+            $selected = g.$el.find('.selected');
+            equal($selected.length, 3, 'two are selected');
+            equal(trim($selected.find('td.col-text_field').eq(0).text()),
+                'item 1', 'correct row selected');
+            equal(trim($selected.find('td.col-text_field').eq(1).text()),
+                'item 2', 'correct row selected');
+            equal(trim($selected.find('td.col-text_field').eq(2).text()),
+                'item 3', 'correct row selected');
+
+            start();
+        });
+    });
+
     module('resizing');
 
     var resizable = function(colModelClass) {


### PR DESCRIPTION
somehow we've made it this far and `grid.select([/* ... */])` is not a
thing that works. this commit adds that capability and a unit test for
it.
