### PR TITLE
handle checkbox columns in  powergrid asformwidget

### DIFF
--- a/src/widgets/powergrid.js
+++ b/src/widgets/powergrid.js
@@ -68,7 +68,7 @@ define([
             _.bindAll(this, '_onColumnChange', '_onColumnResize',
                     '_onModelChange', '_onMultiselectableRowClick',
                     '_onSelectableRowClick', '_onSearchCompleted',
-                    '_onSearchCleared', 'disable', 'enable');
+                    '_onSearchCleared', 'disable', 'enable', 'rerender');
 
             this.on('columnchange', this._onColumnChange);
             this.on('columnresize', this._onColumnResize);

--- a/src/widgets/powergrid/asformwidget.js
+++ b/src/widgets/powergrid/asformwidget.js
@@ -16,22 +16,43 @@ define([
         });
 
         this._onChangeFormValue = function(evtName, xhr, model, changed) {
-            var prop = this._asFormWidgetSelectedProp();
-            if (changed[prop]) {
+            var selectedProp = this._asFormWidgetSelectedProp();
+            if (changed[selectedProp]) {
                 this.trigger('change');
             }
         };
 
+        this._asFormWidgetCheckBoxColumn = function() {
+            return _.find(this.get('columnModel').columns, function(c) {
+                return c instanceof CheckBoxColumn;
+            });
+        };
+
+        this._asFormWidgetIsMultiSelect = function() {
+            var cb = this._asFormWidgetCheckBoxColumn();
+            return cb?
+                cb.get('type') === 'checkbox' :
+                this.get('selectable') === 'multi';
+        };
+
         this._asFormWidgetSelectedProp = function() {
+            var cb;
             if (this._asFormWidgetSelectedPropName) {
                 return this._asFormWidgetSelectedPropName;
             }
-            var cb = _.find(this.get('columnModel').columns, function(c) {
-                return c instanceof CheckBoxColumn;
-            });
-            return cb?
+            return (cb = this._asFormWidgetCheckBoxColumn())?
                 this._asFormWidgetSelectedPropName = cb.get('prop') :
                 this._asFormWidgetSelectedPropName = this.get('selectedAttr');
+        };
+
+        this._asFormWidgetSelected = function() {
+            var selectedProp = this._asFormWidgetSelectedProp(),
+                cb = this._asFormWidgetCheckBoxColumn(),
+                multi = this._asFormWidgetIsMultiSelect(),
+                where = multi? 'where' : 'findWhere';
+            return cb?
+                _[where](this.get('models'), selectedProp, true) :
+                this.selected();
         };
 
         this.clearStatus = function(opts) {
@@ -43,8 +64,9 @@ define([
         };
 
         this.getValue = function() {
-            var m = this.selected();
-            return m && m.get(prop);
+            var multi = this._asFormWidgetIsMultiSelect(),
+                m = this._asFormWidgetSelected();
+            return multi? m && _.mpluck(m, prop) : m && m.get(prop);
         };
 
         this.setStatus = function(type, msg) {
@@ -59,27 +81,59 @@ define([
             return this;
         };
 
-        this.setValue = function(newValue) {
-            var attr = this.get('selectedAttr');
-            if ((_.isArray(newValue) && newValue.length === 0) ||
-                    newValue === void 0) {
-                this.unselect();
-            } else {
-                newValue = _.isArray(newValue)? newValue : [newValue];
-                this.select(_.find(this.get('models'), function(m) {
-                    return _.indexOf(newValue, m.get(prop)) >= 0;
+        this._setValue = function(values) {
+            var changes, cb = this._asFormWidgetCheckBoxColumn(),
+                selectedProp = this._asFormWidgetSelectedProp(),
+                models = _.filter(this.get('models'), function(m) {
+                    return _.indexOf(values, m.get(prop)) >= 0;
+                });
+            if (cb) {
+                changes = _.compact(_.map(this.get('models'), function(m) {
+                    if (!cb._isDisabled(m)) {
+                        if (values.indexOf(m.get(prop)) >= 0) {
+                            if (!m.get(selectedProp)) {
+                                return {model: m, value: true};
+                            }
+                        } else {
+                            if (m.get(selectedProp)) {
+                                return {model: m, value: false};
+                            }
+                        }
+                    }
                 }));
+                this._disableRerender = true;
+                _.each(changes, function(change, i) {
+                    change.model.set(selectedProp, change.value, {
+                        silent: i+1 < changes.length
+                    });
+                });
+                this._disableRerender = false;
+                if (changes.length > 0) {
+                    if (changes.length > 2) {
+                        this.rerender();
+                    } else {
+                        _.map(_.pluck(changes, 'model'), this.rerender);
+                    }
+                }
+            } else {
+                this.select(models);
             }
+        };
+
+        this.setValue = function(newValue) {
+            this._setValue(_.isArray(newValue)? newValue : [newValue]);
             return this;
         };
 
         this.update = _.wrap(this.update, function(update, changed) {
             if (changed.collection) {
                 if (this.previous('collection')) {
-                    this.previous('collection').off('change', this._onChangeFormValue);
+                    this.previous('collection')
+                        .off('change', this._onChangeFormValue);
                 }
                 if (this.get('collection')) {
-                    this.get('collection').on('change', this._onChangeFormValue);
+                    this.get('collection')
+                        .on('change', this._onChangeFormValue);
                 }
             }
             return update.apply(this, _.rest(arguments, 1));

--- a/src/widgets/powergrid/column/test.js
+++ b/src/widgets/powergrid/column/test.js
@@ -3,14 +3,16 @@ define([
     'vendor/jquery',
     'vendor/underscore',
     'vendor/moment',
+    './../../powergrid',
     './checkboxcolumn',
     './asdatetime',
     './asbytes',
     './asenumeration',
     './asnumber',
+    './../asformwidget',
     './../utils'
-], function($, _, moment, CheckBoxColumn, asDateTime, asBytes, asEnumeration,
-    asNumber, utils) {
+], function($, _, moment, PowerGrid, CheckBoxColumn, asDateTime, asBytes,
+    asEnumeration, asNumber, asFormWidget, utils) {
 
     var setup = utils.setup,
         BasicColumnModel = utils.BasicColumnModel,
@@ -165,6 +167,79 @@ define([
             });
         });
     }
+
+    var FormWidgetPowerGrid = PowerGrid.extend();
+    asFormWidget.call(FormWidgetPowerGrid.prototype);
+
+    asyncTest('checkbox column with asformwidget', function() {
+        setup({
+            gridClass: FormWidgetPowerGrid,
+            gridOptions: {
+                columnModelClass: BasicColumnModel.extend({
+                    columnClasses: [CheckBoxColumn.extend()]
+                        .concat(BasicColumnModel.prototype.columnClasses)
+                })
+            }
+        }).then(function(g) {
+            var $checked, val, cb = g.get('columnModel').columns[0],
+                prop = cb.get('prop'),
+                models = g.get('models');
+
+            g.setValue(val = [2, 3, 4]);
+            deepEqual(_.mpluck(_.mwhere(models, prop, true), 'id'), val);
+            equal(($checked = g.$el.find('input:checked')).length, 3);
+            $checked.parent().siblings('.col-text_field').each(function(i, el) {
+                equal($.trim($(el).text()), 'item ' + (val[i]-1));
+            });
+            deepEqual(g.getValue(), val);
+
+            g.setValue(val = [7, 8]);
+            deepEqual(_.mpluck(_.mwhere(models, prop, true), 'id'), val);
+            equal(($checked = g.$el.find('input:checked')).length, 2);
+            $checked.parent().siblings('.col-text_field').each(function(i, el) {
+                equal($.trim($(el).text()), 'item ' + (val[i]-1));
+            });
+            deepEqual(g.getValue(), val);
+
+            start();
+        });
+    });
+
+    asyncTest('checkbox radio column with asformwidget', function() {
+        setup({
+            appendTo: 'body',
+            gridClass: FormWidgetPowerGrid,
+            gridOptions: {
+                columnModelClass: BasicColumnModel.extend({
+                    columnClasses: [CheckBoxColumn.extend({
+                        defaults: {type: 'radio'}
+                    })].concat(BasicColumnModel.prototype.columnClasses)
+                })
+            }
+        }).then(function(g) {
+            var $checked, val, cb = g.get('columnModel').columns[0],
+                prop = cb.get('prop'),
+                models = g.get('models');
+
+            g.setValue(val = 2);
+            deepEqual(_.mpluck(_.mwhere(models, prop, true), 'id'), [val]);
+            equal(($checked = g.$el.find('input:checked')).length, 1);
+            $checked.parent().siblings('.col-text_field').each(function(i, el) {
+                equal($.trim($(el).text()), 'item ' + (val-1));
+            });
+            deepEqual(g.getValue(), val);
+
+            g.setValue(val = 8);
+            deepEqual(_.mpluck(_.mwhere(models, prop, true), 'id'), [val]);
+            equal(($checked = g.$el.find('input:checked')).length, 1);
+            $checked.parent().siblings('.col-text_field').each(function(i, el) {
+                equal($.trim($(el).text()), 'item ' + (val-1));
+            });
+            deepEqual(g.getValue(), val);
+
+            start();
+        });
+    });
 
     module('date column');
 


### PR DESCRIPTION
this makes the `asFormWidget` mixins intelligently handle the case where
the grid has a checkbox column. it also adds support for multi-select,
either through checkbox columns or multiselection.
